### PR TITLE
ECO-5370: Fix Regexp::TimeoutError in custom_word_wrap

### DIFF
--- a/lib/actionmailer-text/html_to_plain_text.rb
+++ b/lib/actionmailer-text/html_to_plain_text.rb
@@ -107,9 +107,25 @@ module ActionMailer
 
       # Taken from Rails' word_wrap helper (http://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-word_wrap)
       def self.custom_word_wrap(txt, line_length)
-        txt.split("\n").collect do |line|
-          line.length > line_length ? line.gsub(/(.{1,#{line_length}})(\s+|$)/, "\\1\n").strip : line
-        end * "\n"
+        txt.split("\n").map { |line| wrap_long_line(line, line_length) }.join("\n")
+      end
+
+      def self.wrap_long_line(line, line_length)
+        return line if line.length <= line_length
+
+        wrapped = []
+        while line.length > line_length
+          idx = line[0, line_length + 1].rindex(/\s/)
+          if idx && idx.positive?
+            wrapped << line[0, idx]
+            line = line[idx..].lstrip
+          else
+            wrapped << line[0, line_length]
+            line = line[line_length..]
+          end
+        end
+        wrapped << line unless line.empty?
+        wrapped.join("\n")
       end
     end
   end

--- a/spec/actionmailer-text/html_to_plain_text_spec.rb
+++ b/spec/actionmailer-text/html_to_plain_text_spec.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'spec_helper'
+require 'benchmark'
 
 describe ActionMailer::Text::HtmlToPlainText do
   it 'converts a fragment' do
@@ -133,6 +134,17 @@ describe ActionMailer::Text::HtmlToPlainText do
     lens = []
     txt.each_line { |l| lens << l.length }
     expect(lens.max).to be <= 20
+  end
+
+  it 'wraps long no-whitespace lines without backtracking' do
+    raw = "<p>#{'a' * 5000}</p>"
+
+    txt = nil
+    elapsed = Benchmark.realtime { txt = subject.convert_to_text(raw, 65) }
+
+    expect(elapsed).to be < 1.0
+    lens = txt.each_line.map(&:length)
+    expect(lens.max).to be <= 66
   end
 
   it 'converts links' do


### PR DESCRIPTION
## Summary

- Replace the backtracking `(.{1,N})(\s+|$)` gsub in `custom_word_wrap` with a linear loop that scans a `line_length+1` window for the rightmost whitespace and falls back to a hard break when none exists.
- Normal inputs produce the same output (the existing `wraps lines` spec still passes).
- Pathological inputs (long URLs, encoded tracking links, table cells flattened to one line) no longer trip Ruby 3.2's `Regexp.timeout`.

Fixes the production crashes tracked at [Sentry KIT-RAILS-WV](https://kit-qq.sentry.io/issues/KIT-RAILS-WV) and Linear [ECO-5370](https://linear.app/kit/issue/ECO-5370/patch-custom-word-wrap-in-actionmailer-text-fork-to-use-linear-scan) (parent: [ECO-5369](https://linear.app/kit/issue/ECO-5369/fix-regexptimeouterror-in-email-plaintext-conversion)).

## Test plan

- [x] `bundle exec rspec spec/actionmailer-text/html_to_plain_text_spec.rb` passes (21/21, including the new `wraps long no-whitespace lines without backtracking` regression).
- [ ] After merge, bump the `ref:` in the Kit Rails app's `Gemfile` from `1ffe836563` to this commit (handled in the parent issue's PR).

Note: `spec/actionmailer-text/multipart_spec.rb` has one pre-existing failure on master unrelated to this change.